### PR TITLE
Inconsistent timer

### DIFF
--- a/modules/desktop_view/src/GamePanel.cpp
+++ b/modules/desktop_view/src/GamePanel.cpp
@@ -388,7 +388,7 @@ void fsweep::GamePanel::OnTimer(wxTimerEvent& WXUNUSED(e))
 {
   auto& model = this->model.get();
   model.UpdateTime(this->getDeltaTime());
-  this->DrawChanged();
+  this->DrawChanged(true);
 }
 
 bool fsweep::GamePanel::TryChangePixelScale(int new_pixel_scale)
@@ -501,21 +501,11 @@ void fsweep::GamePanel::DrawAll()
   }
 }
 
-void fsweep::GamePanel::DrawChanged()
+void fsweep::GamePanel::DrawChanged(bool timer_only)
 {
   const auto& model = this->model.get();
   const auto buttons_wide = model.GetGameConfiguration().GetButtonsWide();
   [[maybe_unused]] wxClientDC dc(this);
-  auto score_lcd = fsweep::LcdNumber(model.GetBombsLeft());
-  for (std::size_t digit_i = 0; digit_i < 3; digit_i++)
-  {
-    const auto lcd_sprite = fsweep::getSpriteFromDigit(score_lcd[digit_i]);
-    if (this->game_panel_state.score_lcd[digit_i] != lcd_sprite)
-    {
-      dc.DrawBitmap(this->getBitmap(lcd_sprite), this->getScorePoint(digit_i), false);
-      this->game_panel_state.score_lcd[digit_i] = lcd_sprite;
-    }
-  }
   const auto time_lcd = fsweep::LcdNumber(this->getTimerSeconds());
   for (std::size_t digit_i = 0; digit_i < 3; digit_i++)
   {
@@ -526,6 +516,18 @@ void fsweep::GamePanel::DrawChanged()
       this->game_panel_state.time_lcd[digit_i] = lcd_sprite;
     }
   }
+  if (timer_only) return;
+  auto score_lcd = fsweep::LcdNumber(model.GetBombsLeft());
+  for (std::size_t digit_i = 0; digit_i < 3; digit_i++)
+  {
+    const auto lcd_sprite = fsweep::getSpriteFromDigit(score_lcd[digit_i]);
+    if (this->game_panel_state.score_lcd[digit_i] != lcd_sprite)
+    {
+      dc.DrawBitmap(this->getBitmap(lcd_sprite), this->getScorePoint(digit_i), false);
+      this->game_panel_state.score_lcd[digit_i] = lcd_sprite;
+    }
+  }
+
   const auto face_sprite = this->getFaceSprite();
   if (face_sprite != this->game_panel_state.face_sprite)
   {

--- a/modules/desktop_view/src/GamePanel.cpp
+++ b/modules/desktop_view/src/GamePanel.cpp
@@ -111,8 +111,7 @@ const int MILLISECONDS_PER_SECOND = 1000;
 
 void fsweep::GamePanel::startClock()
 {
-  this->stopwatch = wxStopWatch();
-  this->stopwatch.Start();
+  this->stopwatch.Start(0);
   this->last_time = 0;
   this->timer.Start(MILLISECONDS_PER_SECOND);
 }

--- a/modules/desktop_view/src/GamePanel.cpp
+++ b/modules/desktop_view/src/GamePanel.cpp
@@ -108,12 +108,13 @@ unsigned long fsweep::GamePanel::getDeltaTime()
 }
 
 const int MILLISECONDS_PER_SECOND = 1000;
+const int TIMER_INTERVAL = MILLISECONDS_PER_SECOND / 15;
 
 void fsweep::GamePanel::startClock()
 {
   this->stopwatch.Start(0);
   this->last_time = 0;
-  this->timer.Start(MILLISECONDS_PER_SECOND);
+  this->timer.Start(TIMER_INTERVAL);
 }
 
 void fsweep::GamePanel::stopClock()

--- a/modules/desktop_view/src/GamePanel.hpp
+++ b/modules/desktop_view/src/GamePanel.hpp
@@ -89,7 +89,7 @@ namespace fsweep
     bool TryChangePixelScale(int new_pixel_scale);
     int GetPixelScale() const noexcept;
     void DrawAll();
-    void DrawChanged();
+    void DrawChanged(bool timer_only = false);
 
     static wxSize GetPixelDimensions(int pixel_scale,
                                      const fsweep::GameConfiguration& configuration) noexcept;


### PR DESCRIPTION
This fixes issues with the `GamePanel::timer` and `GamePanel::stop_watch` being out of sync on windows platform, causing strange behavior with the drawn LCD timer sprites. It was fixed by increasing the timer event interval to 15 times per second. A parameter was added to the `GamePanel::DrawChanged()` to draw timer updates only, which is set to `true` when called by the timer event to decrease the performance impact of this change.

Also, instead of constructing a `wxStopWatch` in `startClock()` in order to clear its timer value to 0 before restarting it, `stop_watch.Start(0)` is called to set the timer value to 0 and restart it all at once.

resolves #2 