### PR TITLE
Mouse fixes

### DIFF
--- a/modules/desktop_view/src/GamePanel.cpp
+++ b/modules/desktop_view/src/GamePanel.cpp
@@ -185,7 +185,7 @@ fsweep::Sprite fsweep::GamePanel::getButtonSprite(int x, int y)
     {
       const auto& hover_button = this->hover_button_o.value();
       if ((hover_button == button_position) ||
-          (this->right_down && hover_button.IsNear(button_position)))
+          (model.GetGameState() == fsweep::GameState::Playing && this->right_down && hover_button.IsNear(button_position)))
       {
         if (fsweep::ButtonState() == fsweep::ButtonState::Questioned)
         {

--- a/modules/desktop_view/src/GamePanel.cpp
+++ b/modules/desktop_view/src/GamePanel.cpp
@@ -131,11 +131,11 @@ fsweep::Sprite fsweep::GamePanel::getFaceSprite()
   if (model.GetGameState() == fsweep::GameState::None ||
       model.GetGameState() == fsweep::GameState::Playing)
   {
-    if (this->left_down && this->hover_face)
+    if (this->left_down&& !this->buttons_locked && this->hover_face)
     {
       return fsweep::Sprite::ButtonSmileDown;
     }
-    else if (this->left_down && this->hover_button_o.has_value())
+    else if (this->left_down && !this->buttons_locked && this->hover_button_o.has_value())
     {
       const auto& hover_button = this->hover_button_o.value();
       const auto& button = model.GetButton(hover_button.x, hover_button.y);

--- a/modules/desktop_view/src/GamePanel.cpp
+++ b/modules/desktop_view/src/GamePanel.cpp
@@ -352,23 +352,23 @@ void fsweep::GamePanel::OnLeftRelease(wxMouseEvent& WXUNUSED(e))
 
 void fsweep::GamePanel::OnRightDown(wxMouseEvent& WXUNUSED(e))
 {
-  this->right_down = true;
-  this->DrawChanged();
-}
-
-void fsweep::GamePanel::OnRightRelease(wxMouseEvent& WXUNUSED(e))
-{
   auto& model = this->model.get();
+  this->right_down = true;
   if (model.GetGameState() == fsweep::GameState::Playing)
   {
     model.UpdateTime(this->getDeltaTime());
   }
-  this->right_down = false;
   if (!this->left_down && this->hover_button_o.has_value())
   {
     auto& hover_button = this->hover_button_o.value();
     model.AltClickButton(hover_button.x, hover_button.y);
   }
+  this->DrawChanged();
+}
+
+void fsweep::GamePanel::OnRightRelease(wxMouseEvent& WXUNUSED(e))
+{
+  this->right_down = false;
   this->DrawChanged();
 }
 

--- a/modules/desktop_view/src/GamePanel.hpp
+++ b/modules/desktop_view/src/GamePanel.hpp
@@ -43,6 +43,7 @@ namespace fsweep
     std::array<wxBitmap, static_cast<std::size_t>(fsweep::Sprite::Count)> scaled_bitmaps;
     bool left_down = false;
     bool right_down = false;
+    bool buttons_locked = false;
     bool hover_face = false;
     bool mouse_hover = true;
     int pixel_scale = 1;


### PR DESCRIPTION
Alt click buttons to place flags or otherwise when the right button is pressed instead of released.

Fix the behavior of area clicking. When an area click is done, do not allow any more clicks until all buttons are released. 

Do not draw buttons as visually held down when mouse buttons are down but it is not possible for them to be clicked at the given time.

closes #3, closes #4, closes #15