### PR TITLE
0.2.0 beta

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ cmake_minimum_required(VERSION 3.19)
 
 project(
     fosssweeper
-    VERSION 0.1.0
+    VERSION 0.2.0
     DESCRIPTION "An open source clone of a popular mine avoidance game"
     LANGUAGES C CXX
 )

--- a/modules/desktop_view/src/GameFrame.cpp
+++ b/modules/desktop_view/src/GameFrame.cpp
@@ -48,10 +48,11 @@ void fsweep::GameFrame::resizeGamePanel(wxSize size)
 }
 
 fsweep::GameFrame::GameFrame(fsweep::DesktopView& view)
-    : view(std::ref(view)), wxFrame(nullptr, fsweep::ID::Main, "FossSweeper")
+    : view(std::ref(view))
+    , wxFrame(NULL, wxID_ANY, "FossSweeper", wxDefaultPosition, wxDefaultSize,
+              wxDEFAULT_FRAME_STYLE & ~(wxRESIZE_BORDER | wxMAXIMIZE_BOX))
 {
   this->SetIcon(wxIcon(fsweep::ICON_XPM_DATA));
-  this->SetWindowStyle(wxDEFAULT_FRAME_STYLE & ~(wxRESIZE_BORDER | wxMAXIMIZE_BOX));
 
   // create top menu bar
   auto menu_bar = new wxMenuBar;

--- a/modules/desktop_view/src/GamePanel.cpp
+++ b/modules/desktop_view/src/GamePanel.cpp
@@ -185,7 +185,7 @@ fsweep::Sprite fsweep::GamePanel::getButtonSprite(int x, int y)
     {
       const auto& hover_button = this->hover_button_o.value();
       if ((hover_button == button_position) ||
-          (this->right_down && hover_button.IsNear(button_position)))
+          (model.GetGameState() == fsweep::GameState::Playing && this->right_down && hover_button.IsNear(button_position)))
       {
         if (fsweep::ButtonState() == fsweep::ButtonState::Questioned)
         {

--- a/modules/desktop_view/src/GamePanel.cpp
+++ b/modules/desktop_view/src/GamePanel.cpp
@@ -131,11 +131,11 @@ fsweep::Sprite fsweep::GamePanel::getFaceSprite()
   if (model.GetGameState() == fsweep::GameState::None ||
       model.GetGameState() == fsweep::GameState::Playing)
   {
-    if (this->left_down && this->hover_face)
+    if (this->left_down&& !this->buttons_locked && this->hover_face)
     {
       return fsweep::Sprite::ButtonSmileDown;
     }
-    else if (this->left_down && this->hover_button_o.has_value())
+    else if (this->left_down && !this->buttons_locked && this->hover_button_o.has_value())
     {
       const auto& hover_button = this->hover_button_o.value();
       const auto& button = model.GetButton(hover_button.x, hover_button.y);

--- a/modules/desktop_view/src/GamePanel.cpp
+++ b/modules/desktop_view/src/GamePanel.cpp
@@ -108,13 +108,13 @@ unsigned long fsweep::GamePanel::getDeltaTime()
 }
 
 const int MILLISECONDS_PER_SECOND = 1000;
+const int TIMER_INTERVAL = MILLISECONDS_PER_SECOND / 15;
 
 void fsweep::GamePanel::startClock()
 {
-  this->stopwatch = wxStopWatch();
-  this->stopwatch.Start();
+  this->stopwatch.Start(0);
   this->last_time = 0;
-  this->timer.Start(MILLISECONDS_PER_SECOND);
+  this->timer.Start(TIMER_INTERVAL);
 }
 
 void fsweep::GamePanel::stopClock()
@@ -388,7 +388,7 @@ void fsweep::GamePanel::OnTimer(wxTimerEvent& WXUNUSED(e))
 {
   auto& model = this->model.get();
   model.UpdateTime(this->getDeltaTime());
-  this->DrawChanged();
+  this->DrawChanged(true);
 }
 
 bool fsweep::GamePanel::TryChangePixelScale(int new_pixel_scale)
@@ -501,21 +501,11 @@ void fsweep::GamePanel::DrawAll()
   }
 }
 
-void fsweep::GamePanel::DrawChanged()
+void fsweep::GamePanel::DrawChanged(bool timer_only)
 {
   const auto& model = this->model.get();
   const auto buttons_wide = model.GetGameConfiguration().GetButtonsWide();
   [[maybe_unused]] wxClientDC dc(this);
-  auto score_lcd = fsweep::LcdNumber(model.GetBombsLeft());
-  for (std::size_t digit_i = 0; digit_i < 3; digit_i++)
-  {
-    const auto lcd_sprite = fsweep::getSpriteFromDigit(score_lcd[digit_i]);
-    if (this->game_panel_state.score_lcd[digit_i] != lcd_sprite)
-    {
-      dc.DrawBitmap(this->getBitmap(lcd_sprite), this->getScorePoint(digit_i), false);
-      this->game_panel_state.score_lcd[digit_i] = lcd_sprite;
-    }
-  }
   const auto time_lcd = fsweep::LcdNumber(this->getTimerSeconds());
   for (std::size_t digit_i = 0; digit_i < 3; digit_i++)
   {
@@ -526,6 +516,18 @@ void fsweep::GamePanel::DrawChanged()
       this->game_panel_state.time_lcd[digit_i] = lcd_sprite;
     }
   }
+  if (timer_only) return;
+  auto score_lcd = fsweep::LcdNumber(model.GetBombsLeft());
+  for (std::size_t digit_i = 0; digit_i < 3; digit_i++)
+  {
+    const auto lcd_sprite = fsweep::getSpriteFromDigit(score_lcd[digit_i]);
+    if (this->game_panel_state.score_lcd[digit_i] != lcd_sprite)
+    {
+      dc.DrawBitmap(this->getBitmap(lcd_sprite), this->getScorePoint(digit_i), false);
+      this->game_panel_state.score_lcd[digit_i] = lcd_sprite;
+    }
+  }
+
   const auto face_sprite = this->getFaceSprite();
   if (face_sprite != this->game_panel_state.face_sprite)
   {

--- a/modules/desktop_view/src/GamePanel.cpp
+++ b/modules/desktop_view/src/GamePanel.cpp
@@ -352,23 +352,23 @@ void fsweep::GamePanel::OnLeftRelease(wxMouseEvent& WXUNUSED(e))
 
 void fsweep::GamePanel::OnRightDown(wxMouseEvent& WXUNUSED(e))
 {
-  this->right_down = true;
-  this->DrawChanged();
-}
-
-void fsweep::GamePanel::OnRightRelease(wxMouseEvent& WXUNUSED(e))
-{
   auto& model = this->model.get();
+  this->right_down = true;
   if (model.GetGameState() == fsweep::GameState::Playing)
   {
     model.UpdateTime(this->getDeltaTime());
   }
-  this->right_down = false;
   if (!this->left_down && this->hover_button_o.has_value())
   {
     auto& hover_button = this->hover_button_o.value();
     model.AltClickButton(hover_button.x, hover_button.y);
   }
+  this->DrawChanged();
+}
+
+void fsweep::GamePanel::OnRightRelease(wxMouseEvent& WXUNUSED(e))
+{
+  this->right_down = false;
   this->DrawChanged();
 }
 

--- a/modules/desktop_view/src/GamePanel.hpp
+++ b/modules/desktop_view/src/GamePanel.hpp
@@ -89,7 +89,7 @@ namespace fsweep
     bool TryChangePixelScale(int new_pixel_scale);
     int GetPixelScale() const noexcept;
     void DrawAll();
-    void DrawChanged();
+    void DrawChanged(bool timer_only = false);
 
     static wxSize GetPixelDimensions(int pixel_scale,
                                      const fsweep::GameConfiguration& configuration) noexcept;

--- a/modules/desktop_view/src/GamePanel.hpp
+++ b/modules/desktop_view/src/GamePanel.hpp
@@ -43,6 +43,7 @@ namespace fsweep
     std::array<wxBitmap, static_cast<std::size_t>(fsweep::Sprite::Count)> scaled_bitmaps;
     bool left_down = false;
     bool right_down = false;
+    bool buttons_locked = false;
     bool hover_face = false;
     bool mouse_hover = true;
     int pixel_scale = 1;


### PR DESCRIPTION
This release contains many bugfixes, and brings FossSweeper closer to its 1.0 release.

Bugfixes:
* Fixed issues with the LCD timer on some platforms.
* Fixed the game window being resizable and maximizable on some platforms when it shouldn't be.
* Fixed area clicking (chording) to be more consistent with Windows XP minesweeper.
* Fixed drawing of buttons visually held when clicking them is not possible due to the current game state.