### PR TITLE
Fix links to code of conduct in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -127,7 +127,7 @@ body:
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.md).
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/Journeyman-dev/FossSweeper/blob/main/CODE_OF_CONDUCT.md).
       options:
         - label: I agree to follow this project's Code of Conduct.
           required: true

--- a/.github/ISSUE_TEMPLATE/build_problem.yml
+++ b/.github/ISSUE_TEMPLATE/build_problem.yml
@@ -147,7 +147,7 @@ body:
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.md).
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/Journeyman-dev/FossSweeper/blob/main/CODE_OF_CONDUCT.md).
       options:
         - label: I agree to follow this project's Code of Conduct.
           required: true


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2022 Daniel Valcour <fosssweeper@gmail.com>

SPDX-License-Identifier: GPL-3.0-or-later
-->

<!--

NOTICE:

This is a template for a pull request. Please replace the text in each section with your own explanations.

For more information about contributing to our project, please view our Contributing Guidelines in the CONTRIBUTING.md file in the root directory of the code repository.

While you participate in our community, you must follow our Code of Conduct in the CODE_OF_CONDUCT.md file in the root directory of the code repository.

This entry field uses Markdown syntax for advanced text formatting. If you would like to preview how this post will appear with Markdown applied, click the preview tab above. You can read about Markdown syntax in the official GitHub documentation website:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

-->

# Description of Changes

Fix links to the Contributing Guidelines in each issue template. The old link expected it in the .github/ISSUE_TEMPLATES/ folder, which is wrong.

# Closing Issues

mentioned in #30 (does not close).
