### PR TITLE
Add releases for x86 builds

### DIFF
--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         platform:
           - {
-              Name: Windows VS2022,
+              Name: Windows VS2022 x64,
               os: windows-2022,
               cpack_generator: ZIP,
               package_extension: zip,
@@ -35,7 +35,16 @@ jobs:
               arch: "x64-windows",
             }
           - {
-              Name: Linux GCC,
+              Name: Windows VS2022 x86,
+              os: windows-2022,
+              cpack_generator: ZIP,
+              package_extension: zip,
+              cc: cl.exe,
+              cxx: cl.exe,
+              arch: "x86-windows",
+            }
+          - {
+              Name: Linux GCC x64,
               os: ubuntu-22.04,
               cpack_generator: TGZ,
               package_extension: tar.gz,
@@ -44,13 +53,31 @@ jobs:
               arch: "x64-linux",
             }
           - {
-              Name: MacOS Clang,
+              Name: Linux GCC x86,
+              os: ubuntu-22.04,
+              cpack_generator: TGZ,
+              package_extension: tar.gz,
+              cc: gcc-10,
+              cxx: g++-10,
+              arch: "x86-linux",
+            }
+          - {
+              Name: MacOS Clang x64,
               os: macos-12,
               cpack_generator: TGZ,
               package_extension: tar.gz,
               cc: clang,
               cxx: clang++,
               arch: "x64-osx",
+            }
+          - {
+              Name: MacOS Clang x86,
+              os: macos-12,
+              cpack_generator: TGZ,
+              package_extension: tar.gz,
+              cc: clang,
+              cxx: clang++,
+              arch: "x86-osx",
             }
         build_type: [Release]
     env:


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2022 Daniel Valcour <fosssweeper@gmail.com>

SPDX-License-Identifier: GPL-3.0-or-later
-->

<!--

NOTICE:

This is a template for a pull request. Please replace the text in each section with your own explanations.

For more information about contributing to our project, please view our Contributing Guidelines in the CONTRIBUTING.md file in the root directory of the code repository.

While you participate in our community, you must follow our Code of Conduct in the CODE_OF_CONDUCT.md file in the root directory of the code repository.

This entry field uses Markdown syntax for advanced text formatting. If you would like to preview how this post will appear with Markdown applied, click the preview tab above. You can read about Markdown syntax in the official GitHub documentation website:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

-->

# Description of Changes

Add releases for each operating system and configuration.

Apple is technically depreciating 32 bit, but add it anyways because it still might work on some older devices.

# Closing Issues

closes #44 