### PR TITLE
Fix header guard typo in wx_include.hpp

### DIFF
--- a/modules/desktop_view/src/wx_include.hpp
+++ b/modules/desktop_view/src/wx_include.hpp
@@ -20,7 +20,7 @@
  *
  */
 
-#ifndef FFSWEEP_WX_INCLUDE_HPP
+#ifndef FSWEEP_WX_INCLUDE_HPP
 #  define FSWEEP_WX_INCLUDE_HPP
 
 #  include <wx/wxprec.h>


### PR DESCRIPTION


<!--
SPDX-FileCopyrightText: 2022 Daniel Valcour <fosssweeper@gmail.com>

SPDX-License-Identifier: GPL-3.0-or-later
-->

<!--

NOTICE:

This is a template for a pull request. Please replace the text in each section with your own explanations.

For more information about contributing to our project, please view our Contributing Guidelines in the CONTRIBUTING.md file in the root directory of the code repository.

While you participate in our community, you must follow our Code of Conduct in the CODE_OF_CONDUCT.md file in the root directory of the code repository.

This entry field uses Markdown syntax for advanced text formatting. If you would like to preview how this post will appear with Markdown applied, click the preview tab above. You can read about Markdown syntax in the official GitHub documentation website:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

-->

# Description of Changes

This pull fixes a header guard typo in wx_include.hpp. This typo only caused warnings on some platforms, but could cause errors in the future if not fixed.

# Closing Issues

None.