### PR TITLE
Only chord on area click if requirements met

### DIFF
--- a/modules/model/include/fsweep/Model.hpp
+++ b/modules/model/include/fsweep/Model.hpp
@@ -53,6 +53,7 @@ namespace fsweep
     fsweep::Button& getButton(int x, int y);
     void pressButton(int x, int y);
     void floodFillClick(int x, int y);
+    bool choordingPossible(int x, int y);
     void surroundingButtonAction(
         const fsweep::ButtonPosition& center_position,
         std::function<void(const fsweep::Button&, const fsweep::ButtonPosition&)> action);

--- a/modules/model/src/Model.cpp
+++ b/modules/model/src/Model.cpp
@@ -108,6 +108,23 @@ void fsweep::Model::floodFillClick(int x, int y)
   } while (!this->flood_fill_stack.empty());
 }
 
+bool fsweep::Model::choordingPossible(int x, int y)
+{
+  const auto& button = this->getButton(x, y);
+  if (button.GetButtonState() != fsweep::ButtonState::Down) return false;
+  auto surrounding_flags = 0;
+  this->surroundingButtonAction(
+      fsweep::ButtonPosition(x, y),
+      [&](const fsweep::Button& button, const fsweep::ButtonPosition position)
+      {
+        if (button.GetButtonState() == fsweep::ButtonState::Flagged)
+        {
+          surrounding_flags++;
+        }
+      });
+  return surrounding_flags == button.GetSurroundingBombs();
+}
+
 void fsweep::Model::surroundingButtonAction(
     const fsweep::ButtonPosition& center_position,
     std::function<void(const fsweep::Button&, const fsweep::ButtonPosition&)> action)
@@ -290,6 +307,7 @@ void fsweep::Model::AltClickButton(int x, int y)
 void fsweep::Model::AreaClickButton(int x, int y)
 {
   if (this->game_state != fsweep::GameState::Playing) return;
+  if (!this->choordingPossible(x, y)) return;
   const auto buttons_wide = this->game_configuration.GetButtonsWide();
   const auto buttons_tall = this->game_configuration.GetButtonsTall();
   const fsweep::ButtonPosition center_position(x, y);

--- a/modules/test/src/model_test.cpp
+++ b/modules/test/src/model_test.cpp
@@ -607,16 +607,16 @@ SCENARIO("A Button of a Model is area clicked")
   {
     fsweep::Model model(fsweep::GameConfiguration(fsweep::GameDifficulty::Beginner), true,
                         fsweep::GameState::Playing, 0,
-                        "bq......"
-                        "bb......"
-                        "......b."
-                        "........"
-                        "........"
-                        "........"
-                        ".b....bb"
-                        "......bd");
+                        "bq...dc."
+                        "bb...b.."
+                        "..ddddd."
+                        ".bd.c.d."
+                        "ccdddd.."
+                        "b.f.c.d."
+                        "...dddbb"
+                        "ddddddbd");
 
-    WHEN("A Button is area clicked and no bombs are hit")
+    WHEN("A Button is area clicked where chording is possible and no bombs are hit")
     {
       model.AreaClickButton(4, 4);
 
@@ -625,47 +625,77 @@ SCENARIO("A Button of a Model is area clicked")
         CHECK(model.GetGameState() == fsweep::GameState::Playing);
       }
 
-      THEN("All the area clicked Button objects are down")
+      THEN("All the near Button objects have the correct state")
       {
         CHECK(model.GetButton(3, 3).GetButtonState() == fsweep::ButtonState::Down);
-        CHECK(model.GetButton(4, 3).GetButtonState() == fsweep::ButtonState::Down);
+        CHECK(model.GetButton(4, 3).GetButtonState() == fsweep::ButtonState::Flagged);
         CHECK(model.GetButton(5, 3).GetButtonState() == fsweep::ButtonState::Down);
         CHECK(model.GetButton(3, 4).GetButtonState() == fsweep::ButtonState::Down);
         CHECK(model.GetButton(4, 4).GetButtonState() == fsweep::ButtonState::Down);
         CHECK(model.GetButton(5, 4).GetButtonState() == fsweep::ButtonState::Down);
         CHECK(model.GetButton(3, 5).GetButtonState() == fsweep::ButtonState::Down);
-        CHECK(model.GetButton(4, 5).GetButtonState() == fsweep::ButtonState::Down);
+        CHECK(model.GetButton(4, 5).GetButtonState() == fsweep::ButtonState::Flagged);
         CHECK(model.GetButton(5, 5).GetButtonState() == fsweep::ButtonState::Down);
-      }
-
-      THEN("Button objects outside of the area that are bombless get flood fill clicked")
-      {
-        CHECK(model.GetButton(5, 0).GetButtonState() == fsweep::ButtonState::Down);
       }
     }
 
-    WHEN("A Button is area clicked and a bomb is hit")
+    WHEN("A Button is area clicked where chording is possible and a bomb is hit")
     {
-      model.AreaClickButton(5, 2);
+      model.AreaClickButton(2, 4);
 
       THEN("The GameState is Dead") { CHECK(model.GetGameState() == fsweep::GameState::Dead); }
 
-      THEN("All the area clicked Button objects are down")
+      THEN("All the near Button objects have the correct state")
       {
-        CHECK(model.GetButton(4, 1).GetButtonState() == fsweep::ButtonState::Down);
-        CHECK(model.GetButton(5, 1).GetButtonState() == fsweep::ButtonState::Down);
-        CHECK(model.GetButton(6, 1).GetButtonState() == fsweep::ButtonState::Down);
-        CHECK(model.GetButton(4, 2).GetButtonState() == fsweep::ButtonState::Down);
-        CHECK(model.GetButton(5, 2).GetButtonState() == fsweep::ButtonState::Down);
-        CHECK(model.GetButton(6, 2).GetButtonState() == fsweep::ButtonState::Down);
-        CHECK(model.GetButton(4, 3).GetButtonState() == fsweep::ButtonState::Down);
-        CHECK(model.GetButton(5, 3).GetButtonState() == fsweep::ButtonState::Down);
-        CHECK(model.GetButton(6, 3).GetButtonState() == fsweep::ButtonState::Down);
+        CHECK(model.GetButton(1, 3).GetButtonState() == fsweep::ButtonState::Down);
+        CHECK(model.GetButton(2, 3).GetButtonState() == fsweep::ButtonState::Down);
+        CHECK(model.GetButton(3, 3).GetButtonState() == fsweep::ButtonState::Down);
+        CHECK(model.GetButton(1, 4).GetButtonState() == fsweep::ButtonState::Flagged);
+        CHECK(model.GetButton(2, 4).GetButtonState() == fsweep::ButtonState::Down);
+        CHECK(model.GetButton(3, 4).GetButtonState() == fsweep::ButtonState::Down);
+        CHECK(model.GetButton(1, 5).GetButtonState() == fsweep::ButtonState::Down);
+        CHECK(model.GetButton(2, 5).GetButtonState() == fsweep::ButtonState::Flagged);
+        CHECK(model.GetButton(3, 5).GetButtonState() == fsweep::ButtonState::Down);
+      }
+    }
+
+    WHEN("A button is area clicked where chording is not possible because there are more surrounding bombs than surrounding flags")
+    {
+      model.AreaClickButton(5, 0);
+
+      THEN("The GameState is still Playing")
+      {
+        CHECK(model.GetGameState() == fsweep::GameState::Playing);
       }
 
-      THEN("Button objects outside of the area that are bombless get flood fill clicked")
+      THEN("All the near Button objects have the same state")
       {
+        CHECK(model.GetButton(4, 0).GetButtonState() == fsweep::ButtonState::None);
         CHECK(model.GetButton(5, 0).GetButtonState() == fsweep::ButtonState::Down);
+        CHECK(model.GetButton(6, 0).GetButtonState() == fsweep::ButtonState::Flagged);
+        CHECK(model.GetButton(4, 1).GetButtonState() == fsweep::ButtonState::None);
+        CHECK(model.GetButton(5, 1).GetButtonState() == fsweep::ButtonState::None);
+        CHECK(model.GetButton(6, 1).GetButtonState() == fsweep::ButtonState::None);
+      }
+    }
+
+    WHEN("A button is area clicked where chording is not possible because it is not down")
+    {
+      model.AreaClickButton(3, 0);
+
+      THEN("The GameState is still Playing")
+      {
+        CHECK(model.GetGameState() == fsweep::GameState::Playing);
+      }
+
+      THEN("All the near Button objects have the same state")
+      {
+        CHECK(model.GetButton(2, 0).GetButtonState() == fsweep::ButtonState::None);
+        CHECK(model.GetButton(3, 0).GetButtonState() == fsweep::ButtonState::None);
+        CHECK(model.GetButton(4, 0).GetButtonState() == fsweep::ButtonState::None);
+        CHECK(model.GetButton(2, 1).GetButtonState() == fsweep::ButtonState::None);
+        CHECK(model.GetButton(3, 1).GetButtonState() == fsweep::ButtonState::None);
+        CHECK(model.GetButton(4, 1).GetButtonState() == fsweep::ButtonState::None);
       }
     }
   }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2022 Daniel Valcour <fosssweeper@gmail.com>

SPDX-License-Identifier: GPL-3.0-or-later
-->

<!--

NOTICE:

This is a template for a pull request. Please replace the text in each section with your own explanations.

For more information about contributing to our project, please view our Contributing Guidelines in the CONTRIBUTING.md file in the root directory of the code repository.

While you participate in our community, you must follow our Code of Conduct in the CODE_OF_CONDUCT.md file in the root directory of the code repository.

This entry field uses Markdown syntax for advanced text formatting. If you would like to preview how this post will appear with Markdown applied, click the preview tab above. You can read about Markdown syntax in the official GitHub documentation website:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

-->

# Description of Changes

Can only chord from a button if it is down and the surrounding bomb count matches the surrounding flags.

# Closing Issues

closes #30
