### PR TITLE
Call NewGame in Model constructor

### DIFF
--- a/modules/model/include/fsweep/Model.hpp
+++ b/modules/model/include/fsweep/Model.hpp
@@ -43,7 +43,7 @@ namespace fsweep
     fsweep::GameState game_state = fsweep::GameState::Default;
     bool questions_enabled = false;
     int flag_count = 0;
-    int buttons_left = game_configuration.GetButtonCount();
+    int buttons_left = 0;
     unsigned long game_time = 0;
     std::random_device rnd = std::random_device();
     std::mt19937 rng = std::mt19937(rnd());
@@ -61,7 +61,7 @@ namespace fsweep
     void calculateSurroundingBombs();
 
    public:
-    Model() noexcept = default;
+    Model() noexcept;
     Model(fsweep::GameConfiguration game_configuration, bool questions_enabled,
           fsweep::GameState game_state, int game_time, std::string_view button_string);
 

--- a/modules/model/include/fsweep/Model.hpp
+++ b/modules/model/include/fsweep/Model.hpp
@@ -59,6 +59,7 @@ namespace fsweep
         std::function<void(const fsweep::Button&, const fsweep::ButtonPosition&)> action);
     void placeBombs(int initial_x, int initial_y);
     void calculateSurroundingBombs();
+    void tryWin() noexcept;
 
    public:
     Model() noexcept;

--- a/modules/model/src/Model.cpp
+++ b/modules/model/src/Model.cpp
@@ -27,6 +27,11 @@
 #include <stdexcept>
 #include <string>
 
+fsweep::Model::Model() noexcept
+{
+  this->NewGame();
+}
+
 fsweep::Model::Model(fsweep::GameConfiguration game_configuration, bool questions_enabled,
                      fsweep::GameState game_state, int game_time, std::string_view button_string)
     : game_configuration(game_configuration)

--- a/modules/model/src/Model.cpp
+++ b/modules/model/src/Model.cpp
@@ -335,6 +335,7 @@ void fsweep::Model::AreaClickButton(int x, int y)
           this->pressButton(position.x, position.y);
         }
       });
+  this->tryWin();
 }
 
 void fsweep::Model::UpdateTime(unsigned long delta_time)

--- a/modules/model/src/Model.cpp
+++ b/modules/model/src/Model.cpp
@@ -27,10 +27,7 @@
 #include <stdexcept>
 #include <string>
 
-fsweep::Model::Model() noexcept
-{
-  this->NewGame();
-}
+fsweep::Model::Model() noexcept { this->NewGame(); }
 
 fsweep::Model::Model(fsweep::GameConfiguration game_configuration, bool questions_enabled,
                      fsweep::GameState game_state, int game_time, std::string_view button_string)

--- a/modules/model/src/Model.cpp
+++ b/modules/model/src/Model.cpp
@@ -239,6 +239,14 @@ void fsweep::Model::calculateSurroundingBombs()
   }
 }
 
+void fsweep::Model::tryWin() noexcept
+{
+  if (this->buttons_left <= 0)
+  {
+    this->game_state = fsweep::GameState::Cool;
+  }
+}
+
 void fsweep::Model::NewGame()
 {
   std::fill(this->buttons.begin(), this->buttons.end(), fsweep::Button());
@@ -288,10 +296,7 @@ void fsweep::Model::ClickButton(int x, int y)
   {
     this->game_state = fsweep::GameState::Dead;
   }
-  else if (this->buttons_left <= 0)
-  {
-    this->game_state = fsweep::GameState::Cool;
-  }
+  this->tryWin();
 }
 
 void fsweep::Model::AltClickButton(int x, int y)

--- a/modules/test/src/model_test.cpp
+++ b/modules/test/src/model_test.cpp
@@ -40,8 +40,9 @@ SCENARIO("A Model is constructed with its default constructor")
 
     THEN("There is a beginner difficulty amount of buttons left")
     {
-      CHECK(model.GetButtonsLeft() == fsweep::GameConfiguration::BEGINNER_BUTTONS_WIDE *
-                                          fsweep::GameConfiguration::BEGINNER_BUTTONS_TALL);
+      CHECK(model.GetButtonsLeft() == (fsweep::GameConfiguration::BEGINNER_BUTTONS_WIDE *
+                                       fsweep::GameConfiguration::BEGINNER_BUTTONS_TALL) -
+                                          fsweep::GameConfiguration::BEGINNER_BOMB_COUNT);
     }
 
     THEN("The GameState is None") { CHECK(model.GetGameState() == fsweep::GameState::None); }
@@ -659,7 +660,9 @@ SCENARIO("A Button of a Model is area clicked")
       }
     }
 
-    WHEN("A button is area clicked where chording is not possible because there are more surrounding bombs than surrounding flags")
+    WHEN(
+        "A button is area clicked where chording is not possible because there are more "
+        "surrounding bombs than surrounding flags")
     {
       model.AreaClickButton(5, 0);
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2022 Daniel Valcour <fosssweeper@gmail.com>

SPDX-License-Identifier: GPL-3.0-or-later
-->

<!--

NOTICE:

This is a template for a pull request. Please replace the text in each section with your own explanations.

For more information about contributing to our project, please view our Contributing Guidelines in the CONTRIBUTING.md file in the root directory of the code repository.

While you participate in our community, you must follow our Code of Conduct in the CODE_OF_CONDUCT.md file in the root directory of the code repository.

This entry field uses Markdown syntax for advanced text formatting. If you would like to preview how this post will appear with Markdown applied, click the preview tab above. You can read about Markdown syntax in the official GitHub documentation website:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

-->

# Description of Changes

By calling the NewGame function in the Model's constructor, the setting of values of a NewGame can be encapsulated within the NewGame function, including the initial game right after the window is opened. This fixes an issue with Model properties being invalid, causing the first game after the window is opened to be unwinnable.

Also, I fixed another unwinnable game issue by checking for if the game was won after chording (area clicking).

# Closing Issues

closes #56
