### PR TITLE
Fix gitignore path to version header

### DIFF
--- a/modules/generated/.gitignore
+++ b/modules/generated/.gitignore
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License along with FossSweeper. If not, see <https://www.gnu.org/licenses/>.
 # 
 
-include/version.hpp
+include/fsweep/version.hpp
 include/fsweep/short_hash.hpp
 src/license.cpp
 src/credits.cpp


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2022 Daniel Valcour <fosssweeper@gmail.com>

SPDX-License-Identifier: GPL-3.0-or-later
-->

<!--

NOTICE:

This is a template for a pull request. Please replace the text in each section with your own explanations.

For more information about contributing to our project, please view our Contributing Guidelines in the CONTRIBUTING.md file in the root directory of the code repository.

While you participate in our community, you must follow our Code of Conduct in the CODE_OF_CONDUCT.md file in the root directory of the code repository.

This entry field uses Markdown syntax for advanced text formatting. If you would like to preview how this post will appear with Markdown applied, click the preview tab above. You can read about Markdown syntax in the official GitHub documentation website:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

-->

# Description of Changes

Fixing an issue with a generated file having the wrong path in .gitignore file.

# Closing Issues

None