### PR TITLE
Macos bundle 2nd fix attempt

### DIFF
--- a/modules/desktop_view/CMakeLists.txt
+++ b/modules/desktop_view/CMakeLists.txt
@@ -69,7 +69,6 @@ elseif(APPLE)
         ${FSWEEP_DESKTOP_SOURCES}
         ${FSWEEP_DESKTOP_OSX_ICON}
     )
-    set_target_properties(fsweep_desktop_view PROPERTIES MACOSX_BUNDLE_BUNDLE_NAME "FossSweeper")
     set_source_files_properties(FSWEEP_DESKTOP_OSX_ICON 
         PROPERTIES
             MACOSX_PACKAGE_LOCATION "Resources"
@@ -79,6 +78,7 @@ elseif(APPLE)
 	          MACOSX_BUNDLE_ICON_FILE "${FSWEEP_MACOSX_BUNDLE_ICON_FILE}"
 	          MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/rc/osxbundle.plist.in"
     set_target_properties(fsweep_desktop_view PROPERTIES
+              MACOSX_BUNDLE_BUNDLE_NAME "FossSweeper"
     )
 elseif(UNIX)
     add_executable(fsweep_desktop_view

--- a/modules/desktop_view/CMakeLists.txt
+++ b/modules/desktop_view/CMakeLists.txt
@@ -73,12 +73,14 @@ elseif(APPLE)
         PROPERTIES
             MACOSX_PACKAGE_LOCATION "Resources"
     )
-	          MACOSX_BUNDLE_SHORT_VERSION_STRING ${PROJECT_VERSION}
-	          MACOSX_BUNDLE_LONG_VERSION_STRING ${PROJECT_VERSION}
-	          MACOSX_BUNDLE_ICON_FILE "${FSWEEP_MACOSX_BUNDLE_ICON_FILE}"
-	          MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/rc/osxbundle.plist.in"
     set_target_properties(fsweep_desktop_view PROPERTIES
               MACOSX_BUNDLE_BUNDLE_NAME "FossSweeper"
+              MACOSX_BUNDLE_BUNDLE_VERSION ${PROJECT_VERSION}
+              MACOSX_BUNDLE_INFO_STRING "An open source clone of a popular mine avoidance game."
+              MACOSX_BUNDLE_SHORT_VERSION_STRING ${PROJECT_VERSION}
+              MACOSX_BUNDLE_LONG_VERSION_STRING ${PROJECT_VERSION}
+              MACOSX_BUNDLE_ICON_FILE "${FSWEEP_MACOSX_BUNDLE_ICON_FILE}"
+              MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/rc/osxbundle.plist.in"
     )
 elseif(UNIX)
     add_executable(fsweep_desktop_view

--- a/modules/desktop_view/CMakeLists.txt
+++ b/modules/desktop_view/CMakeLists.txt
@@ -74,11 +74,11 @@ elseif(APPLE)
         PROPERTIES
             MACOSX_PACKAGE_LOCATION "Resources"
     )
-    set_target_properties(${GUI_ONLY_BINARIES} PROPERTIES
 	          MACOSX_BUNDLE_SHORT_VERSION_STRING ${PROJECT_VERSION}
 	          MACOSX_BUNDLE_LONG_VERSION_STRING ${PROJECT_VERSION}
 	          MACOSX_BUNDLE_ICON_FILE "${FSWEEP_MACOSX_BUNDLE_ICON_FILE}"
 	          MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/rc/osxbundle.plist.in"
+    set_target_properties(fsweep_desktop_view PROPERTIES
     )
 elseif(UNIX)
     add_executable(fsweep_desktop_view
@@ -114,7 +114,7 @@ if(FSWEEP_INSTALL_DESKTOP)
       configure_file("${CMAKE_CURRENT_SOURCE_DIR}/rc/fosssweeper.desktop.in" "${CMAKE_CURRENT_SOURCE_DIR}/rc/fosssweeper.desktop")
       install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/rc/fosssweeper.desktop" DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/applications")
     elseif(APPLE)
-    	string(APPEND CMAKE_INSTALL_PREFIX "FossSweeper.app/Contents")
+        string(APPEND CMAKE_INSTALL_PREFIX "FossSweeper.app/Contents")
     endif()
     set(CPACK_RESOURCE_FILE_LICENSE "${FSWEEP_CMAKE_SOURCE_DIR}/COPYING")
     set(CPACK_STRIP_FILES TRUE)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2022 Daniel Valcour <fosssweeper@gmail.com>

SPDX-License-Identifier: GPL-3.0-or-later
-->

<!--

NOTICE:

This is a template for a pull request. Please replace the text in each section with your own explanations.

For more information about contributing to our project, please view our Contributing Guidelines in the CONTRIBUTING.md file in the root directory of the code repository.

While you participate in our community, you must follow our Code of Conduct in the CODE_OF_CONDUCT.md file in the root directory of the code repository.

This entry field uses Markdown syntax for advanced text formatting. If you would like to preview how this post will appear with Markdown applied, click the preview tab above. You can read about Markdown syntax in the official GitHub documentation website:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

-->

# Description of Changes

This is the second attempt at fixing the OSX icon. I will release a tweak version for it to be tested by a person who owns an Apple computer.

# Closing Issues

might close https://github.com/Journeyman-dev/FossSweeper/issues/59