### PR TITLE
Remove buttons_locked set on left release while chording

### DIFF
--- a/modules/desktop_view/src/GamePanel.cpp
+++ b/modules/desktop_view/src/GamePanel.cpp
@@ -330,7 +330,6 @@ void fsweep::GamePanel::OnLeftRelease(wxMouseEvent& WXUNUSED(e))
       if (this->right_down)
       {
         model.AreaClickButton(hover_button.x, hover_button.y);
-        this->buttons_locked = true;
       }
       else
       {


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2022 Daniel Valcour <fosssweeper@gmail.com>

SPDX-License-Identifier: GPL-3.0-or-later
-->

<!--

NOTICE:

This is a template for a pull request. Please replace the text in each section with your own explanations.

For more information about contributing to our project, please view our Contributing Guidelines in the CONTRIBUTING.md file in the root directory of the code repository.

While you participate in our community, you must follow our Code of Conduct in the CODE_OF_CONDUCT.md file in the root directory of the code repository.

This entry field uses Markdown syntax for advanced text formatting. If you would like to preview how this post will appear with Markdown applied, click the preview tab above. You can read about Markdown syntax in the official GitHub documentation website:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

-->

# Description of Changes

Chording multiple times without releasing the alt mouse button should be possible.

# Closing Issues

closes #60

# Request for Credit

None