### PR TITLE
Capture and release the mouse

### DIFF
--- a/modules/desktop_view/src/GamePanel.cpp
+++ b/modules/desktop_view/src/GamePanel.cpp
@@ -79,6 +79,7 @@ void fsweep::GamePanel::OnLeftPress(wxMouseEvent& WXUNUSED(e))
 {
   auto& desktop_model = this->desktop_view.get().GetDesktopModel();
   desktop_model.LeftPress();
+  this->CaptureMouse(); // prevents issues when mouse leaves the window on Windows platform
   this->DrawChanged();
 }
 
@@ -86,6 +87,7 @@ void fsweep::GamePanel::OnLeftRelease(wxMouseEvent& WXUNUSED(e))
 {
   auto& desktop_model = this->desktop_view.get().GetDesktopModel();
   desktop_model.LeftRelease(this->timer);
+  this->ReleaseMouse(); // undo the CaptureMouse() from the press event
   this->DrawChanged();
 }
 
@@ -93,6 +95,7 @@ void fsweep::GamePanel::OnRightPress(wxMouseEvent& WXUNUSED(e))
 {
   auto& desktop_model = this->desktop_view.get().GetDesktopModel();
   desktop_model.RightPress(this->timer);
+  this->CaptureMouse();
   this->DrawChanged();
 }
 
@@ -100,6 +103,7 @@ void fsweep::GamePanel::OnRightRelease(wxMouseEvent& WXUNUSED(e))
 {
   auto& desktop_model = this->desktop_view.get().GetDesktopModel();
   desktop_model.RightRelease();
+  this->ReleaseMouse();
   this->DrawChanged();
 }
 


### PR DESCRIPTION


Co-Authored-By: Tianyi Pu <44583944+putianyi889@users.noreply.github.com>

<!--
SPDX-FileCopyrightText: 2022 Daniel Valcour <fosssweeper@gmail.com>

SPDX-License-Identifier: GPL-3.0-or-later
-->

<!--

NOTICE:

This is a template for a pull request. Please replace the text in each section with your own explanations.

For more information about contributing to our project, please view our Contributing Guidelines in the CONTRIBUTING.md file in the root directory of the code repository.

While you participate in our community, you must follow our Code of Conduct in the CODE_OF_CONDUCT.md file in the root directory of the code repository.

This entry field uses Markdown syntax for advanced text formatting. If you would like to preview how this post will appear with Markdown applied, click the preview tab above. You can read about Markdown syntax in the official GitHub documentation website:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

-->

# Description of Changes

Capturing the mouse while a button is pressed will prevent issues on Windows platform. If this is not done, mouse release events wont be processed when the mouse has left the window.

# Closing Issues

closes #76