### PR TITLE
Only add or release capture if possible

### DIFF
--- a/modules/desktop_view/src/GamePanel.cpp
+++ b/modules/desktop_view/src/GamePanel.cpp
@@ -79,7 +79,10 @@ void fsweep::GamePanel::OnLeftPress(wxMouseEvent& WXUNUSED(e))
 {
   auto& desktop_model = this->desktop_view.get().GetDesktopModel();
   desktop_model.LeftPress();
-  this->CaptureMouse(); // prevents issues when mouse leaves the window on Windows platform
+  if (!this->HasCapture())
+  {
+    this->CaptureMouse(); // prevents issues when mouse leaves the window on Windows platform
+  }
   this->DrawChanged();
 }
 
@@ -87,7 +90,10 @@ void fsweep::GamePanel::OnLeftRelease(wxMouseEvent& WXUNUSED(e))
 {
   auto& desktop_model = this->desktop_view.get().GetDesktopModel();
   desktop_model.LeftRelease(this->timer);
-  this->ReleaseMouse(); // undo the CaptureMouse() from the press event
+  if (this->HasCapture())
+  {
+    this->ReleaseMouse(); // undo the CaptureMouse() from the press event
+  }
   this->DrawChanged();
 }
 
@@ -95,7 +101,10 @@ void fsweep::GamePanel::OnRightPress(wxMouseEvent& WXUNUSED(e))
 {
   auto& desktop_model = this->desktop_view.get().GetDesktopModel();
   desktop_model.RightPress(this->timer);
-  this->CaptureMouse();
+  if (!this->HasCapture())
+  {
+    this->CaptureMouse();
+  }
   this->DrawChanged();
 }
 
@@ -103,7 +112,10 @@ void fsweep::GamePanel::OnRightRelease(wxMouseEvent& WXUNUSED(e))
 {
   auto& desktop_model = this->desktop_view.get().GetDesktopModel();
   desktop_model.RightRelease();
-  this->ReleaseMouse();
+  if (this->HasCapture())
+  {
+    this->ReleaseMouse();
+  }
   this->DrawChanged();
 }
 


### PR DESCRIPTION
Check to make sure capture is possible before capturing or releasing capture.

<!--
SPDX-FileCopyrightText: 2022 Daniel Valcour <fosssweeper@gmail.com>

SPDX-License-Identifier: GPL-3.0-or-later
-->

<!--

NOTICE:

This is a template for a pull request. Please replace the text in each section with your own explanations.

For more information about contributing to our project, please view our Contributing Guidelines in the CONTRIBUTING.md file in the root directory of the code repository.

While you participate in our community, you must follow our Code of Conduct in the CODE_OF_CONDUCT.md file in the root directory of the code repository.

This entry field uses Markdown syntax for advanced text formatting. If you would like to preview how this post will appear with Markdown applied, click the preview tab above. You can read about Markdown syntax in the official GitHub documentation website:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

-->

# Description of Changes

Fix a crash that sometimes occurs with mouse capturing with it is already captured, or releasing when it is not captured.

# Closing Issues

None
