### PR TITLE
Add space to line in credits

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -25,6 +25,6 @@ Thanks to all who have helped to make FossSweeper what it is today!
 Code Contributors:
 Daniel Valcour (GitHub: @Journeyman-dev)
 Tiany Pu (GitHub: @putianyi889)
-
+ 
 Bug Reports
 TurtleCheez28


### PR DESCRIPTION


<!--
SPDX-FileCopyrightText: 2022 Daniel Valcour <fosssweeper@gmail.com>

SPDX-License-Identifier: GPL-3.0-or-later
-->

<!--

NOTICE:

This is a template for a pull request. Please replace the text in each section with your own explanations.

For more information about contributing to our project, please view our Contributing Guidelines in the CONTRIBUTING.md file in the root directory of the code repository.

While you participate in our community, you must follow our Code of Conduct in the CODE_OF_CONDUCT.md file in the root directory of the code repository.

This entry field uses Markdown syntax for advanced text formatting. If you would like to preview how this post will appear with Markdown applied, click the preview tab above. You can read about Markdown syntax in the official GitHub documentation website:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

-->

# Description of Changes

Add a missing space to a line in the CREDITS file. This will cause the embedding script to add a newline correctly.

# Closing Issues

None